### PR TITLE
Make file search script use project root dynamically

### DIFF
--- a/commands/web/dev-cspell
+++ b/commands/web/dev-cspell
@@ -10,6 +10,7 @@ source "${0%/*}/dev-utils.sh"
 #          "ddev dev-cspell --files=file1.php,file2.js" (checks specific files)
 
 set -euo pipefail
+docroot=$(grep '^docroot:' .ddev/config.yaml | awk '{print $2}') || docroot="docroot"
 
 # Define extensions for text files
 EXTENSIONS=("php" "module" "js" "css" "twig" "yml" "yaml" "json" "md" "txt")
@@ -35,7 +36,7 @@ if [ -f "./.cspell.json" ]; then
     echo "Using local .cspell.json"
     CONFIG="./.cspell.json"
 else
-    CONFIG="docroot/core/.cspell.json"
+    CONFIG="$docroot/core/.cspell.json"
 fi
 
-node docroot/core/node_modules/cspell/bin.mjs --config "$CONFIG" --color $FILES
+node $docroot/core/node_modules/cspell/bin.mjs --config "$CONFIG" --color $FILES

--- a/commands/web/dev-eslint
+++ b/commands/web/dev-eslint
@@ -10,6 +10,7 @@ source "${0%/*}/dev-utils.sh"
 #          "ddev dev-eslint --files=file1.js,file2.js" (checks specific files)
 
 set -euo pipefail
+docroot=$(grep '^docroot:' .ddev/config.yaml | awk '{print $2}') || docroot="docroot"
 
 # Define extensions for JS files
 EXTENSIONS=("js")
@@ -35,8 +36,8 @@ if [ -f "./.eslintrc.json" ]; then
     echo "Using local .eslintrc.json"
     CONFIG="./.eslintrc.json"
 else
-    CONFIG="docroot/core/.eslintrc.json"
+    CONFIG="$docroot/core/.eslintrc.json"
 fi
 
 # Run ESLint
-node docroot/core/node_modules/eslint/bin/eslint.js --config="$CONFIG" --no-eslintrc -f stylish --color $FILES
+node $docroot/core/node_modules/eslint/bin/eslint.js --config="$CONFIG" --no-eslintrc -f stylish --color $FILES

--- a/commands/web/dev-stylelint
+++ b/commands/web/dev-stylelint
@@ -10,6 +10,7 @@ source "${0%/*}/dev-utils.sh"
 #          "ddev dev-stylelint --files=file1.css,file2.css" (checks specific files)
 
 set -euo pipefail
+docroot=$(grep '^docroot:' .ddev/config.yaml | awk '{print $2}') || docroot="docroot"
 
 # Define extensions for CSS files
 EXTENSIONS=("css")
@@ -35,7 +36,7 @@ if [ -f "./.stylelintrc.json" ]; then
     echo "Using local .stylelintrc.json"
     CONFIG="./.stylelintrc.json"
 else
-    CONFIG="docroot/core/.stylelintrc.json"
+    CONFIG="$docroot/core/.stylelintrc.json"
 fi
 
-node docroot/core/node_modules/stylelint/bin/stylelint.mjs --config "$CONFIG" --color --allow-empty-input $FILES
+node $docroot/core/node_modules/stylelint/bin/stylelint.mjs --config "$CONFIG" --color --allow-empty-input $FILES

--- a/commands/web/dev-utils.sh
+++ b/commands/web/dev-utils.sh
@@ -7,7 +7,8 @@
 get_changed_files() {
     local extensions=("$@")
     local ext_pattern=$(IFS='|'; echo "${extensions[*]}")
-    local custom_path_pattern="docroot/(modules|themes)/custom/.*"
+    local docroot=$(grep '^docroot:' .ddev/config.yaml | awk '{print $2}') || docroot="docroot"
+    local custom_path_pattern="$docroot/(modules|themes)/custom/.*"
     local changed_files=""
 
     # If we're in Bitbucket Pipelines
@@ -35,8 +36,9 @@ get_changed_files() {
 get_all_files() {
     local extensions=("$@")
     local ext_pattern=$(IFS='|'; echo "${extensions[*]}")
+    local docroot=$(grep '^docroot:' .ddev/config.yaml | awk '{print $2}') || docroot="docroot"
 
-    find docroot/modules/custom docroot/themes/custom -type f \
+    find $docroot/modules/custom $docroot/themes/custom -type f \
         -regextype posix-extended \
         -regex ".*\.($ext_pattern)$" \
         -not -path "*/node_modules/*" | tr '\n' ' '


### PR DESCRIPTION
- Read docroot from .ddev/config.yaml
- Support both docroot and web directories
- Prevent unbound variable errors in scripts

## The Issue

- Fixes #2 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/Vardot/ddev-dev-tools/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
