### PR TITLE
New pipelines structure

### DIFF
--- a/examples/bitbucket-pipelines.yml.example
+++ b/examples/bitbucket-pipelines.yml.example
@@ -1,16 +1,21 @@
 #################
-# Version: 2.0.0
+# Version: 2.1.0
 #################
+triggers:
+  pullrequest-push:
+    - condition: BITBUCKET_PR_DESTINATION_BRANCH == "dev" || BITBUCKET_PR_DESTINATION_BRANCH == "development" || BITBUCKET_PR_DESTINATION_BRANCH == "stg" || BITBUCKET_PR_DESTINATION_BRANCH == "staging" || BITBUCKET_PR_DESTINATION_BRANCH == "master" || BITBUCKET_PR_DESTINATION_BRANCH == "production" || BITBUCKET_PR_DESTINATION_BRANCH == "main" || glob(BITBUCKET_PR_DESTINATION_BRANCH, "release/*")
+      pipelines:
+        - all-steps
 
 pipelines:
-  pull-requests:
-    '**':
+  custom:
+    all-steps:
       - step:
           name: 🛠️ Pipelines Initialization
           runs-on:
             - self.hosted
             - linux.shell
-            - main
+            - init
           clone:
             enabled: false
           script:
@@ -21,16 +26,16 @@ pipelines:
             runs-on:
               - self.hosted
               - linux.shell
-              - linting
+              - main
             clone:
               depth: full
             script:
               - git --version
-              - PHP_CHANGED_FILES=$(git diff --name-only --diff-filter=dr origin/$BITBUCKET_PR_DESTINATION_BRANCH...$BITBUCKET_BRANCH | grep -E '(docroot|web)/(modules|themes)/custom/.*\.(php|module)$' | tr '\n' ' ')
-              - JS_CHANGED_FILES=$(git diff --name-only --diff-filter=dr origin/$BITBUCKET_PR_DESTINATION_BRANCH...$BITBUCKET_BRANCH | grep -E '(docroot|web)/(modules|themes)/custom/.*\.(js)$' | tr '\n' ' ')
-              - STYLE_CHANGED_FILES=$(git diff --name-only --diff-filter=dr origin/$BITBUCKET_PR_DESTINATION_BRANCH...$BITBUCKET_BRANCH | grep -E '(docroot|web)/(modules|themes)/custom/.*\.(css)$' | tr '\n' ' ')
-              - TWIG_CHANGED_FILES=$(git diff --name-only --diff-filter=dr origin/$BITBUCKET_PR_DESTINATION_BRANCH...$BITBUCKET_BRANCH | grep -E '(docroot|web)/(modules|themes)/custom/.*\.(twig)$' | tr '\n' ' ')
-              - TEXT_CHANGED_FILES=$(git diff --name-only --diff-filter=dr origin/$BITBUCKET_PR_DESTINATION_BRANCH...$BITBUCKET_BRANCH | grep -E '(docroot|web)/(modules)/custom/.*\.(php|module|js|twig|yml|yaml|json|css|scss|sass|md|txt)$' | tr '\n' ' ')
+              - PHP_CHANGED_FILES=$(git diff --name-only --diff-filter=dr origin/$BITBUCKET_PR_DESTINATION_BRANCH...$BITBUCKET_PR_DESTINATION_BRANCH | grep -E '(docroot|web)/(modules|themes)/custom/.*\.(php|module)$' | tr '\n' ' ')
+              - JS_CHANGED_FILES=$(git diff --name-only --diff-filter=dr origin/$BITBUCKET_PR_DESTINATION_BRANCH...$BITBUCKET_PR_DESTINATION_BRANCH | grep -E '(docroot|web)/(modules|themes)/custom/.*\.(js)$' | tr '\n' ' ')
+              - STYLE_CHANGED_FILES=$(git diff --name-only --diff-filter=dr origin/$BITBUCKET_PR_DESTINATION_BRANCH...$BITBUCKET_PR_DESTINATION_BRANCH | grep -E '(docroot|web)/(modules|themes)/custom/.*\.(css)$' | tr '\n' ' ')
+              - TWIG_CHANGED_FILES=$(git diff --name-only --diff-filter=dr origin/$BITBUCKET_PR_DESTINATION_BRANCH...$BITBUCKET_PR_DESTINATION_BRANCH | grep -E '(docroot|web)/(modules|themes)/custom/.*\.(twig)$' | tr '\n' ' ')
+              - TEXT_CHANGED_FILES=$(git diff --name-only --diff-filter=dr origin/$BITBUCKET_PR_DESTINATION_BRANCH...$BITBUCKET_PR_DESTINATION_BRANCH | grep -E '(docroot|web)/(modules)/custom/.*\.(php|module|js|twig|yml|yaml|json|css|scss|sass|md|txt)$' | tr '\n' ' ')
               - if [ -z "$PHP_CHANGED_FILES" ] && [ -z "$JS_CHANGED_FILES" ] && [ -z "$STYLE_CHANGED_FILES" ] && [ -z "$TWIG_CHANGED_FILES" ] && [ -z "$TEXT_CHANGED_FILES" ]; then
               - echo "No relevant files changed. Skipping Linting..."
               - else
@@ -74,7 +79,7 @@ pipelines:
             runs-on:
               - self.hosted
               - linux.shell
-              - testing
+              - main
             clone:
               depth: full
             script:
@@ -89,6 +94,8 @@ pipelines:
               - export DOCKER_HOST=""
               - export DOCKER_BUILDKIT=1
               - ddev -v
+              - ddev stop --unlist --all --omit-snapshot --remove-data
+              - yes | ddev delete --all --omit-snapshot
               - ddev start
               - ddev add-on get Vardot/ddev-dev-tools
               - ddev restart


### PR DESCRIPTION
This pull request updates the Bitbucket Pipelines example configuration to version 2.1.0, introducing new trigger-based pipeline execution and refactoring the pipeline steps for better organization and maintenance. The changes also update how changed files are detected and add cleanup steps to the DDEV workflow.

Pipeline configuration and triggers:

* Upgraded pipeline version to `2.1.0` and introduced a `triggers` section to run pipelines when pull requests target specific branches, improving automation and flexibility.
* Refactored pipeline definitions to use a custom `all-steps` pipeline, consolidating initialization, linting, and testing steps under a single pipeline for easier management.

File change detection logic:

* Updated the logic for detecting changed files by modifying the `git diff` command to compare the destination branch against itself, which may affect how file changes are detected during pipeline runs.

Pipeline step improvements:

* Standardized the `runs-on` environment for steps to use `main` instead of `linting` or `testing`, simplifying environment configuration. [[1]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L24-R38) [[2]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L77-R82)
* Added DDEV cleanup commands (`ddev stop` and `ddev delete`) before starting and restarting DDEV, ensuring a clean environment for each pipeline execution.