### PR TITLE
Included PHPStan dependencies in install.yaml & Auto generation of ph…

### DIFF
--- a/commands/web/dev-phpstan
+++ b/commands/web/dev-phpstan
@@ -11,6 +11,47 @@ source "${0%/*}/dev-utils.sh"
 
 set -euo pipefail
 
+# Function to generate phpstan.neon if it doesn't exist
+generate_phpstan_config() {
+    if [ ! -f "phpstan.neon" ]; then
+        echo "📝 Generating phpstan.neon configuration file..."
+        cat > phpstan.neon << 'EOF'
+# Configuration file for PHPStan static code checking, see https://phpstan.org .
+includes:
+  - phar://phpstan.phar/conf/bleedingEdge.neon
+
+parameters:
+
+  level: 2
+
+  paths:
+    - docroot/modules/custom
+    - docroot/themes/custom
+
+  excludePaths:
+    # Skip test fixtures.
+    - ../*/node_modules/*
+    - */tests/fixtures/*.php
+    - */tests/fixtures/*.php.gz
+
+  ignoreErrors:
+    # new static() is a best practice in Drupal, so we cannot fix that.
+    - "#^Unsafe usage of new static#"
+
+    # Ignore common errors for now.
+    - "#Drupal calls should be avoided in classes, use dependency injection instead#"
+    - "#^Plugin definitions cannot be altered.#"
+    - "#^Missing cache backend declaration for performance.#"
+    - "#cache tag might be unclear and does not contain the cache key in it.#"
+    - "#^Class .* extends @internal class#"
+EOF
+        echo "✅ Created phpstan.neon configuration file"
+    fi
+}
+
+# Generate phpstan.neon if it doesn't exist
+generate_phpstan_config
+
 # Define extensions for PHP files
 EXTENSIONS=("php" "module")
 
@@ -30,9 +71,6 @@ fi
 
 echo "🔍 Running PHPStan on files:"
 echo "$FILES" | tr ' ' '\n'
-
-# Ensure PHPStan and its Drupal extension are installed
-composer require --dev phpstan/phpstan phpstan/extension-installer mglaman/phpstan-drupal
 
 # Check if phpstan is executable
 check_command_executable "$(command -v phpstan 2>/dev/null || echo './vendor/bin/phpstan')" "phpstan"

--- a/install.yaml
+++ b/install.yaml
@@ -24,6 +24,7 @@ post_install_actions:
   - ddev exec composer require --dev drupal/coder:^8.3 dealerdirect/phpcodesniffer-composer-installer squizlabs/php_codesniffer:^3.7
   - ddev exec composer config allow-plugins.vincentlanglet/twig-cs-fixer true
   - ddev exec composer require --dev vincentlanglet/twig-cs-fixer:^2.5
+  - ddev exec composer require --dev phpstan/phpstan phpstan/extension-installer mglaman/phpstan-drupal
   - |
     if [ -d /var/www/html/docroot/core ]; then
       ddev yarn --cwd /var/www/html/docroot/core/ install


### PR DESCRIPTION
This pull request streamlines the setup and execution of PHPStan static analysis for the project by ensuring the necessary configuration and dependencies are handled automatically. The most significant changes include the automated generation of a default `phpstan.neon` configuration file if it doesn't exist and moving PHPStan dependency installation to the project setup phase.

**PHPStan configuration and setup improvements:**

* Added a shell function in `commands/web/dev-phpstan` to automatically generate a default `phpstan.neon` configuration file if it is missing, ensuring PHPStan can run out-of-the-box.
* Removed the step that installed PHPStan and its extensions every time the script runs; instead, these dependencies are now installed during the initial project setup. [[1]](diffhunk://#diff-8c8160577782ef51ea32ff9c7598a8cd984ed28fe35707176194173dd52aefd1L34-L36) [[2]](diffhunk://#diff-9570a738d573aaa96a20a5901248e66b1502a71cb3d7e6aa2491d70a972ee59bR27)

These changes make the workflow more efficient by reducing redundant installations and ensuring configuration files are present when needed.