### PR TITLE
Pipelines 2.2 & PHPStan in dev-lint

### DIFF
--- a/commands/web/dev-lint
+++ b/commands/web/dev-lint
@@ -30,6 +30,16 @@ if [ "${IS_CI:-false}" = "TRUE" ]; then
         echo "✅ Skipping PHP lint"
     fi
 
+    if [ -n "${PHP_CHANGED_FILES:-}" ]; then
+        echo "➡ PHP Static Analysis..."
+        echo "$PHP_CHANGED_FILES" | tr ' ' '\n'
+        if ! .ddev/commands/web/dev-phpstan --files="$PHP_CHANGED_FILES"; then
+            LINT_STATUS=1
+        fi
+    else
+        echo "✅ Skipping PHP static analysis"
+    fi
+
     if [ -n "${JS_CHANGED_FILES:-}" ]; then
         echo "➡ JS Linting..."
         echo "$JS_CHANGED_FILES" | tr ' ' '\n'
@@ -93,6 +103,11 @@ else
     # Run each tool with the same arguments
     echo "➡ PHP Linting..."
     if ! .ddev/commands/web/dev-phpcs $ARGS; then
+        LINT_STATUS=1
+    fi
+
+    echo "➡ PHP Static Analysis..."
+    if ! .ddev/commands/web/dev-phpstan $ARGS; then
         LINT_STATUS=1
     fi
 

--- a/examples/bitbucket-pipelines.yml.example
+++ b/examples/bitbucket-pipelines.yml.example
@@ -1,5 +1,5 @@
 #################
-# Version: 2.1.0
+# Version: 2.2.0
 #################
 triggers:
   pullrequest-push:
@@ -66,6 +66,7 @@ pipelines:
               - ddev add-on get Vardot/ddev-dev-tools
               - ddev restart
               - ddev exec "if [ -d docroot/core ]; then cd docroot/core && yarn install; elif [ -d web/core ]; then cd web/core && yarn install; else echo 'Neither docroot/core nor web/core found'; exit 1; fi"
+              - ddev yarn install
               - ddev dev-lint
               - fi
             after-script:
@@ -85,12 +86,6 @@ pipelines:
             clone:
               depth: full
             script:
-              - FEATURE_FILES=$(find cypress -name "*.feature" -type f 2>/dev/null | wc -l)
-              - echo "Found $FEATURE_FILES .feature files in cypress folder"
-              - if [ "$FEATURE_FILES" -eq 0 ]; then
-              -   echo "No .feature files found. Skipping automated tests..."
-              -   exit 0
-              - fi
               - chmod 777 .ddev -R
               - chmod 777 docroot/sites/default -R 2>/dev/null || chmod 777 web/sites/default -R 2>/dev/null || true
               - export DOCKER_HOST=""
@@ -102,8 +97,14 @@ pipelines:
               - ddev add-on get Vardot/ddev-dev-tools
               - ddev restart
               - ddev install-drupal
-              - ddev cypress-install
-              - ddev cypress-headless
+              - FEATURE_FILES=$(find cypress -name "*.feature" -type f 2>/dev/null | wc -l)
+              - echo "Found $FEATURE_FILES .feature files in cypress folder"
+              - if [ "$FEATURE_FILES" -eq 0 ]; then
+              -   echo "No .feature files found. Skipping automated tests..."
+              - else
+              -   ddev cypress-install
+              -   ddev cypress-headless
+              - fi
             after-script:
               - chmod 777 .ddev -R || true
               - chmod 777 docroot/sites/default -R 2>/dev/null || chmod 777 web/sites/default -R 2>/dev/null || true


### PR DESCRIPTION
This pull request introduces improvements to the PHP static analysis workflow and enhances the Bitbucket Pipelines example configuration. The main changes include running PHPStan static analysis on changed PHP files, updating the pipeline configuration to run additional dependency installation steps, and refining the automated test execution logic for Cypress feature files.

**PHP Static Analysis Enhancements:**

* Added logic in `commands/web/dev-lint` to run PHPStan static analysis only on changed PHP files if any are detected, improving efficiency in CI runs.
* Ensured PHPStan static analysis is always run in non-CI environments as part of the linting process.

**Bitbucket Pipelines Improvements:**

* Updated the example pipeline version from 2.1.0 to 2.2.0 for clarity and currency.
* Added an explicit `ddev yarn install` step to ensure all dependencies are installed before running linting.
* Moved Cypress feature file detection logic to occur after Drupal installation, and changed the script to only run Cypress tests if feature files are present, preventing unnecessary test runs. [[1]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L88-L93) [[2]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2R100-R107)