### PR TITLE
Exit code 0 when missing SQL backups

### DIFF
--- a/commands/host/dev-lint-all
+++ b/commands/host/dev-lint-all
@@ -15,6 +15,12 @@ if ! ddev dev-phpcs --all; then
     LINT_STATUS=1
 fi
 
+# Run PHPStan on all PHP files
+echo -e "\n➡ Running PHPStan..."
+if ! ddev dev-phpstan --all; then
+    LINT_STATUS=1
+fi
+
 # Run ESLint on all JS files
 echo -e "\n➡ Running ESLint..."
 if ! ddev dev-eslint --all; then

--- a/commands/host/install-drupal
+++ b/commands/host/install-drupal
@@ -24,7 +24,7 @@ else
         mapfile -t db_files < <(find ./backups -maxdepth 1 -type f -name "*.sql.gz")
         if [ ${#db_files[@]} -eq 0 ]; then
             echo "📥 No database backup files found!"
-            exit 1
+            exit 0
         elif [ ${#db_files[@]} -eq 1 ]; then
             selected_db="${db_files[0]}"
             echo "📥 Found one backup: $selected_db"
@@ -42,7 +42,7 @@ else
         ddev drush cr
     else
         echo "📥 Database backup not found!"
-        exit 1
+        exit 0
     fi
 fi
 


### PR DESCRIPTION
This pull request introduces an additional PHP static analysis step to the linting workflow and improves the resilience of the Drupal installation script by making it non-fatal when no database backup is found. The main changes are grouped as follows:

Linting enhancements:
* Added a step to run PHPStan on all PHP files in the `dev-lint-all` script, ensuring static analysis is part of the linting process.

Drupal installation robustness:
* Modified the `install-drupal` script so that it no longer exits with an error when no database backup files are found; it now exits successfully instead, preventing unnecessary failures in automated workflows.
* Updated the handling for missing database backups after attempting to restore, so the script exits successfully instead of with an error, further improving script robustness.