### PR TITLE
Composer allow plugin & PHPStan example

### DIFF
--- a/examples/phpstan.neon.example
+++ b/examples/phpstan.neon.example
@@ -1,0 +1,28 @@
+# Configuration file for PHPStan static code checking, see https://phpstan.org .
+includes:
+  - phar://phpstan.phar/conf/bleedingEdge.neon
+
+parameters:
+
+  level: 2
+
+  paths:
+    - docroot/modules/custom
+    - docroot/themes/custom
+
+  excludePaths:
+    # Skip test fixtures.
+    - ../*/node_modules/*
+    - */tests/fixtures/*.php
+    - */tests/fixtures/*.php.gz
+
+  ignoreErrors:
+    # new static() is a best practice in Drupal, so we cannot fix that.
+    - "#^Unsafe usage of new static#"
+
+    # Ignore common errors for now.
+    - "#Drupal calls should be avoided in classes, use dependency injection instead#"
+    - "#^Plugin definitions cannot be altered.#"
+    - "#^Missing cache backend declaration for performance.#"
+    - "#cache tag might be unclear and does not contain the cache key in it.#"
+    - "#^Class .* extends @internal class#"

--- a/install.yaml
+++ b/install.yaml
@@ -24,6 +24,7 @@ post_install_actions:
   - ddev exec composer require --dev drupal/coder:^8.3 dealerdirect/phpcodesniffer-composer-installer squizlabs/php_codesniffer:^3.7
   - ddev exec composer config allow-plugins.vincentlanglet/twig-cs-fixer true
   - ddev exec composer require --dev vincentlanglet/twig-cs-fixer:^3.0
+  - ddev exec composer config allow-plugins.phpstan/extension-installer true
   - ddev exec composer require --dev phpstan/phpstan phpstan/extension-installer mglaman/phpstan-drupal
   - |
     if [ -d /var/www/html/docroot/core ]; then


### PR DESCRIPTION
This pull request introduces static code analysis tooling using PHPStan to the project. The main changes include adding a PHPStan configuration file and updating installation steps to support PHPStan and its Drupal-specific extensions.

**Tooling and configuration:**

* Added a new example configuration file for PHPStan at `examples/phpstan.neon.example`, specifying analysis level, paths to scan, exclusions, and error ignores tailored for Drupal development.

**Installation workflow:**

* Updated `install.yaml` to configure Composer to allow the PHPStan extension installer and to require PHPStan and its Drupal extension during setup.