### PR TITLE
Changes on Cypress image

### DIFF
--- a/commands/cypress/cypress-headless
+++ b/commands/cypress/cypress-headless
@@ -5,4 +5,17 @@
 ## Usage: cypress-headless [arguments]
 ## Example: "ddev cypress-headless --browser chrome"
 
+# Use a random high display number to avoid conflicts
+DISPLAY_NUM=$((RANDOM % 100 + 100))
+rm -f /tmp/.X${DISPLAY_NUM}-lock 2>/dev/null
+
+Xvfb :${DISPLAY_NUM} -screen 0 1280x1024x24 -nolisten tcp &
+XVFB_PID=$!
+sleep 1
+
+export DISPLAY=:${DISPLAY_NUM}
 cypress run "$@"
+EXIT_CODE=$?
+
+kill $XVFB_PID 2>/dev/null
+exit $EXIT_CODE

--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -1,28 +1,22 @@
 #ddev-generated
 services:
   cypress:
-    image: cypress/included:latest
     container_name: ddev-${DDEV_SITENAME}-cypress
+    hostname: ${DDEV_SITENAME}-cypress
+    image: cypress/included:15.10.0
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
-    user: "${DDEV_UID}:${DDEV_GID}"
-    networks: [default, ddev_default]
-
-    tty: true
-
-    environment:
-      - CYPRESS_baseUrl=${DDEV_PRIMARY_URL}
-      - DISPLAY
-      - HOME=/root
-
-    volumes:
-      # Mount the project root to Cypress's project point
-      - "${DDEV_APPROOT}:/e2e"
-      # Mount DDEV to allow commands
-      - ".:/mnt/ddev_config"
-      # Allow X11 forwarding
-      - /tmp/.X11-unix:/tmp/.X11-unix
-
-    entrypoint: /bin/bash
+      com.ddev.approot: $DDEV_APPROOT
     working_dir: /e2e
+    user: "${UID:-1000}:${GID:-1000}"
+    ipc: host
+    environment:
+      - DISPLAY=${DISPLAY:-:0}
+      - CYPRESS_baseUrl=${DDEV_PRIMARY_URL}
+      - ELECTRON_EXTRA_LAUNCH_ARGS=--disable-gpu --disable-software-rasterizer
+    volumes:
+      - ..:/e2e:cached
+      - ".:/mnt/ddev_config"
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    entrypoint: []
+    command: ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
This pull request updates the Cypress end-to-end testing setup to improve reliability and compatibility, particularly around headless execution and Docker configuration. The main changes include enhancements to the Cypress headless command script and significant updates to the Docker Compose service for Cypress.

**Cypress Headless Execution Improvements:**

* The `cypress-headless` command script now starts an isolated Xvfb server on a random high display number to avoid conflicts, properly sets the `DISPLAY` environment variable, and ensures the Xvfb process is cleaned up after test execution.

**Docker Compose Cypress Service Updates:**

* The Cypress Docker image is pinned to version `15.10.0` (was previously `latest`), and the service now uses the project hostname, sets the working directory to `/e2e`, and updates the user and group to match the host system for better file permissions.
* The environment variables for the Cypress container are updated, including explicit `DISPLAY` settings and Electron launch arguments to disable GPU, which can help with headless stability.
* Volume mounts are updated for improved caching and compatibility, and the container entrypoint and command are changed to keep the container running and ready for test execution.