### PR TITLE
Cypress UI & PHPStan tweaks

### DIFF
--- a/commands/cypress/cypress-ui
+++ b/commands/cypress/cypress-ui
@@ -6,4 +6,30 @@
 ## Usage: cypress-ui [arguments]
 ## Example: "ddev cypress-ui --config cypress.json"
 
-cypress open --project . "$@"
+# Detect OS
+OS="$(uname -s)"
+
+case "$OS" in
+  Darwin*)
+    # macOS - try native display (Docker Desktop may handle this)
+    cypress open --project . "$@"
+    ;;
+  Linux*)
+    # Linux - check if host display is accessible
+    if [ -n "$DISPLAY" ] && command -v xdpyinfo >/dev/null 2>&1 && xdpyinfo -display "$DISPLAY" &>/dev/null; then
+      cypress open --project . "$@"
+    else
+      # Fall back to virtual framebuffer
+      Xvfb :99 -screen 0 1280x720x24 &
+      XVFB_PID=$!
+      export DISPLAY=:99
+      sleep 1
+      cypress open --project . "$@"
+      kill $XVFB_PID 2>/dev/null
+    fi
+    ;;
+  *)
+    # Unknown OS - try direct execution
+    cypress open --project . "$@"
+    ;;
+esac

--- a/commands/web/dev-phpstan
+++ b/commands/web/dev-phpstan
@@ -27,6 +27,8 @@ parameters:
   paths:
     - docroot/modules/custom
     - docroot/themes/custom
+    - web/modules/custom
+    - web/themes/custom
 
   excludePaths:
     # Skip test fixtures.

--- a/examples/phpstan.neon.example
+++ b/examples/phpstan.neon.example
@@ -9,6 +9,8 @@ parameters:
   paths:
     - docroot/modules/custom
     - docroot/themes/custom
+    - web/modules/custom
+    - web/themes/custom
 
   excludePaths:
     # Skip test fixtures.


### PR DESCRIPTION
This pull request introduces improvements to cross-platform compatibility for Cypress UI testing and updates configuration paths for PHPStan analysis. The most significant changes are grouped below:

**Cypress UI Script Improvements:**

* Enhanced the `cypress-ui` command script to detect the operating system and handle Cypress UI launching accordingly:
  * On macOS, uses the native display.
  * On Linux, checks for display availability and falls back to using `Xvfb` (a virtual framebuffer) if necessary.
  * For other OS types, attempts direct execution.

**PHPStan Configuration Updates:**

* Added `web/modules/custom` and `web/themes/custom` to the `paths` analyzed by PHPStan in both `commands/web/dev-phpstan` and the example config, ensuring custom code in both `docroot` and `web` directories is included in static analysis. [[1]](diffhunk://#diff-8c8160577782ef51ea32ff9c7598a8cd984ed28fe35707176194173dd52aefd1R30-R31) [[2]](diffhunk://#diff-ce5fccaf5e65e7850519ba7a8f60aa92d9d994b4baf1b76866a91e8febfb2c00R12-R13)