### PR TITLE
Installing Drupal core-dev & PHPUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ fi
   - `cypress-run` - Run Cypress tests in headless mode
   - `cypress-install` - Install additional npm packages for Cucumber support
 
+- **PHPUnit**
+  - `dev-phpunit` - Run PHPUnit tests on custom modules
+
 It's recommended to run ddev cypress-open first to create configuration and support files. This addon sets CYPRESS_baseUrl to DDEV's primary URL in the docker-compose.cypress.yaml.
 
 **Note:** This addon uses the latest official Cypress Docker image to ensure up-to-date testing capabilities and compatibility.
@@ -229,6 +232,7 @@ Feature: User Login
 
 The addon includes example configurations:
 - `cypress.config.js.example-[cucumber]` - Configuration with Cucumber/Gherkin support
+- `phpunit.xml.example` - PHPUnit configuration for Drupal testing
 
 ### Cypress Usage
 
@@ -257,3 +261,48 @@ xhost +
 
 **Windows:**
 Install [GWSL](https://www.microsoft.com/en-us/p/gwsl/9nl6kd1h33v3) or [VcXsrv](https://sourceforge.net/projects/vcxsrv/)
+
+### PHPUnit Testing
+
+Run PHPUnit tests on your custom Drupal modules.
+
+#### Prerequisites
+
+PHPUnit requires `drupal/core-dev` to be installed:
+
+```bash
+ddev composer require --dev drupal/core-dev --with-all-dependencies
+```
+
+#### Configuration
+
+1. Copy the example configuration to your project root:
+```bash
+cp examples/phpunit.xml.example phpunit.xml
+```
+
+2. Customize the configuration as needed:
+   - Update `SIMPLETEST_BASE_URL` if using a different local URL
+   - Modify database connection in `SIMPLETEST_DB`
+   - Adjust `BROWSERTEST_OUTPUT_DIRECTORY` for test output location
+   - Configure coverage paths to include/exclude specific directories
+
+#### Running Tests
+
+```bash
+ddev dev-phpunit
+```
+
+This command will:
+- Check if `drupal/core-dev` is installed
+- Locate your PHPUnit configuration file (`phpunit.xml`, `phpunit.xml.dist`, or core's default)
+- Run tests on custom modules in `docroot/modules/custom/` or `web/modules/custom/`
+- Display results with colors and test documentation format
+
+#### Configuration File Search Order
+
+The command searches for configuration files in this order:
+1. `/var/www/html/phpunit.xml`
+2. `/var/www/html/phpunit.xml.dist`
+3. `/var/www/html/docroot/core/phpunit.xml.dist`
+4. `/var/www/html/web/core/phpunit.xml.dist`

--- a/commands/web/dev-phpunit
+++ b/commands/web/dev-phpunit
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ## Description: Run PHPUnit tests
-## Usage: phpunit
+## Usage: dev-phpunit
 
 echo "🚦 Running PHPUnit tests..."
 if [ -f /var/www/html/phpunit.xml ]; then

--- a/commands/web/dev-phpunit
+++ b/commands/web/dev-phpunit
@@ -4,6 +4,12 @@ set -euo pipefail
 ## Description: Run PHPUnit tests
 ## Usage: dev-phpunit
 
+# Ensure drupal/core-dev is installed (required for PHPUnit)
+if ! composer show drupal/core-dev &>/dev/null; then
+    echo "❌ drupal/core-dev is not installed. Please install it to run PHPUnit tests."
+    exit 1
+fi
+
 echo "🚦 Running PHPUnit tests..."
 if [ -f /var/www/html/phpunit.xml ]; then
     CONFIG="/var/www/html/phpunit.xml"

--- a/commands/web/dev-phpunit
+++ b/commands/web/dev-phpunit
@@ -8,6 +8,8 @@ set -euo pipefail
 # Ensure drupal/core-dev is installed (required for PHPUnit)
 if ! composer show drupal/core-dev &>/dev/null; then
     echo "❌ drupal/core-dev is not installed. Please install it to run PHPUnit tests."
+    echo "👉 You can install it with dependencies using:"
+    echo "   ddev composer require --dev drupal/core-dev --with-all-dependencies"
     exit 1
 fi
 

--- a/commands/web/dev-phpunit
+++ b/commands/web/dev-phpunit
@@ -30,7 +30,7 @@ elif [ -d /var/www/html/web/modules/custom ]; then
     TEST_DIR="./web/modules/custom/"
 else
     echo "❌ No custom modules directory found."
-    exit 1
+    exit 0
 fi
 
 phpunit -c "$CONFIG" "$TEST_DIR" --colors=always --testdox

--- a/commands/web/dev-phpunit
+++ b/commands/web/dev-phpunit
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+## #ddev-generated
 ## Description: Run PHPUnit tests
 ## Usage: dev-phpunit
 

--- a/commands/web/dev-phpunit
+++ b/commands/web/dev-phpunit
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+## Description: Run PHPUnit tests
+## Usage: phpunit
+
+echo "🚦 Running PHPUnit tests..."
+if [ -f /var/www/html/phpunit.xml ]; then
+    CONFIG="/var/www/html/phpunit.xml"
+elif [ -f /var/www/html/phpunit.xml.dist ]; then
+    CONFIG="/var/www/html/phpunit.xml.dist"
+elif [ -f /var/www/html/docroot/core/phpunit.xml.dist ]; then
+    CONFIG="/var/www/html/docroot/core/phpunit.xml.dist"
+elif [ -f /var/www/html/web/core/phpunit.xml.dist ]; then
+    CONFIG="/var/www/html/web/core/phpunit.xml.dist"
+else
+    echo "❌ No phpunit.xml configuration found."
+    exit 1
+fi
+
+if [ -d /var/www/html/docroot/modules/custom ]; then
+    TEST_DIR="./docroot/modules/custom/"
+elif [ -d /var/www/html/web/modules/custom ]; then
+    TEST_DIR="./web/modules/custom/"
+else
+    echo "❌ No custom modules directory found."
+    exit 1
+fi
+
+phpunit -c "$CONFIG" "$TEST_DIR" --colors=always --testdox

--- a/examples/bitbucket-pipelines.yml.example
+++ b/examples/bitbucket-pipelines.yml.example
@@ -97,6 +97,7 @@ pipelines:
               - ddev add-on get Vardot/ddev-dev-tools
               - ddev restart
               - ddev install-drupal
+              - ddev dev-phpunit
               - FEATURE_FILES=$(find cypress -name "*.feature" -type f 2>/dev/null | wc -l)
               - echo "Found $FEATURE_FILES .feature files in cypress folder"
               - if [ "$FEATURE_FILES" -eq 0 ]; then
@@ -105,6 +106,9 @@ pipelines:
               -   ddev cypress-install
               -   ddev cypress-headless
               - fi
+            artifacts:
+              - cypress/screenshots/**
+              - cypress/videos/**
             after-script:
               - chmod 777 .ddev -R || true
               - chmod 777 docroot/sites/default -R 2>/dev/null || chmod 777 web/sites/default -R 2>/dev/null || true

--- a/examples/phpunit.xml.example
+++ b/examples/phpunit.xml.example
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- For how to customize PHPUnit configuration, see core/tests/README.md. -->
+<!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
+<!-- PHPUnit expects functional tests to be run with either a privileged user
+ or your current system user. See core/tests/README.md and
+ https://www.drupal.org/node/2116263 for details.
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="docroot/core/tests/bootstrap.php" colors="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" beStrictAboutChangesToGlobalState="true" failOnWarning="true" printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" cacheResult="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./includes</directory>
+      <directory>./lib</directory>
+      <directory>./modules</directory>
+      <directory>../modules</directory>
+      <directory>../sites</directory>
+    </include>
+    <exclude>
+      <directory>./modules/*/src/Tests</directory>
+      <directory>./modules/*/tests</directory>
+      <directory>../modules/*/src/Tests</directory>
+      <directory>../modules/*/tests</directory>
+      <directory>../modules/*/*/src/Tests</directory>
+      <directory>../modules/*/*/tests</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="32767"/>
+    <ini name="memory_limit" value="-1"/>
+    <env name="SIMPLETEST_BASE_URL" value="http://localhost"/>
+    <env name="SIMPLETEST_DB" value="mysql://db:db@db/db"/>
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/var/www/html/docroot/sites/simpletest/browser_output"/>
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
+    <!-- To disable deprecation testing completely uncomment the next line. -->
+    <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
+    <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=""/>
+    <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS" value=""/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=""/>
+  </php>
+  <testsuites>
+    <testsuite name="unit">
+      <file>../docroot/core/tests/TestSuites/UnitTestSuite.php</file>
+    </testsuite>
+    <testsuite name="kernel">
+      <file>../docroot/core/tests/TestSuites/KernelTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional">
+      <file>../docroot/core/tests/TestSuites/FunctionalTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional-javascript">
+      <file>../docroot/core/tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+    <testsuite name="build">
+      <file>../docroot/core/tests/TestSuites/BuildTestSuite.php</file>
+    </testsuite>
+  </testsuites>
+  <listeners>
+    <listener class="\Drupal\Tests\Listeners\DrupalListener">
+    </listener>
+  </listeners>
+  <!-- Filter for coverage reports. -->
+</phpunit>

--- a/install.yaml
+++ b/install.yaml
@@ -25,7 +25,7 @@ post_install_actions:
   - ddev exec composer config allow-plugins.vincentlanglet/twig-cs-fixer true
   - ddev exec composer require --dev vincentlanglet/twig-cs-fixer:^3.0
   - ddev exec composer config allow-plugins.phpstan/extension-installer true
-  - ddev exec composer require --dev phpstan/phpstan phpstan/extension-installer mglaman/phpstan-drupal
+  - ddev exec composer require --dev drupal/core-dev:^11 -W ||ddev exec composer require --dev drupal/core-dev:^10 -W
   - |
     if [ -d /var/www/html/docroot/core ]; then
       ddev yarn --cwd /var/www/html/docroot/core/ install

--- a/install.yaml
+++ b/install.yaml
@@ -11,6 +11,7 @@ project_files:
   - commands/web/dev-lint
   - commands/web/dev-phpcs
   - commands/web/dev-phpstan
+  - commands/web/dev-phpunit
   - commands/web/dev-stylelint
   - commands/web/dev-twigcs
   - commands/web/dev-utils.sh

--- a/install.yaml
+++ b/install.yaml
@@ -26,7 +26,7 @@ post_install_actions:
   - ddev exec composer config allow-plugins.vincentlanglet/twig-cs-fixer true
   - ddev exec composer require --dev vincentlanglet/twig-cs-fixer:^3.0
   - ddev exec composer config allow-plugins.phpstan/extension-installer true
-  - ddev exec composer require --dev drupal/core-dev:^11 -W ||ddev exec composer require --dev drupal/core-dev:^10 -W
+  - ddev exec composer require --dev phpstan/phpstan phpstan/extension-installer mglaman/phpstan-drupal
   - |
     if [ -d /var/www/html/docroot/core ]; then
       ddev yarn --cwd /var/www/html/docroot/core/ install


### PR DESCRIPTION
This pull request introduces a new utility script to simplify running PHPUnit tests in the development environment, and updates the project configuration to include this script.

**Testing improvements:**

* Added a new script `commands/web/dev-phpunit` that automates running PHPUnit tests, including checks for required dependencies (`drupal/core-dev`), auto-detection of the appropriate PHPUnit configuration file, and support for running tests in custom module directories.

**Project configuration:**

* Updated `install.yaml` to include the new `commands/web/dev-phpunit` script in the list of project files, ensuring it is available in the development environment.