### PR TITLE
Make PHPUnit return a warning

### DIFF
--- a/commands/web/dev-phpunit
+++ b/commands/web/dev-phpunit
@@ -5,12 +5,11 @@ set -euo pipefail
 ## Description: Run PHPUnit tests
 ## Usage: dev-phpunit
 
-# Ensure drupal/core-dev is installed (required for PHPUnit)
+# Ensure drupal/core-dev is installed (recommended for PHPUnit)
 if ! composer show drupal/core-dev &>/dev/null; then
-    echo "❌ drupal/core-dev is not installed. Please install it to run PHPUnit tests."
+    echo "⚠️ Warning: drupal/core-dev is not installed. Some PHPUnit tests may not work properly."
     echo "👉 You can install it with dependencies using:"
     echo "   ddev composer require --dev drupal/core-dev --with-all-dependencies"
-    exit 1
 fi
 
 echo "🚦 Running PHPUnit tests..."


### PR DESCRIPTION
This pull request makes a small adjustment to the `commands/web/dev-phpunit` script. Instead of requiring `drupal/core-dev` to be installed in order to run PHPUnit tests, the script now issues a warning if it is missing but allows the tests to proceed. This makes it easier to run tests in environments where `drupal/core-dev` is not available, while still informing the user that some tests may not work as expected.