### PR TITLE
DDEV & Docker cleaning commands

### DIFF
--- a/examples/bitbucket-pipelines.yml.example
+++ b/examples/bitbucket-pipelines.yml.example
@@ -1,5 +1,5 @@
 #################
-# Version: 2.2.1
+# Version: 2.2.2
 #################
 triggers:
   pullrequest-push:
@@ -55,8 +55,11 @@ pipelines:
               - export DOCKER_HOST=""
               - export DOCKER_BUILDKIT=1
               - ddev -v
-              - ddev stop --unlist --all --omit-snapshot --remove-data
-              - yes | ddev delete --all --omit-snapshot
+              - ddev poweroff || true
+              - ddev stop --unlist --all --omit-snapshot --remove-data || true
+              - ddev delete --omit-snapshot --yes || true
+              - docker ps -aq --filter "name=ddev-" | xargs -r docker rm -f || true
+              - docker volume ls -q | grep '^ddev-' | xargs -r docker volume rm -f || true
               - ddev start
               - ddev composer config --global github-oauth.github.com $GITHUB_TOKEN
               - ddev composer install --optimize-autoloader
@@ -74,8 +77,11 @@ pipelines:
               - chmod 777 docroot/sites/default -R 2>/dev/null || chmod 777 web/sites/default -R 2>/dev/null || true
               - export DOCKER_HOST=""
               - export DOCKER_BUILDKIT=1
+              - ddev poweroff || true
               - ddev stop --unlist --all --omit-snapshot --remove-data || true
               - ddev delete --omit-snapshot --yes || true
+              - docker ps -aq --filter "name=ddev-" | xargs -r docker rm -f || true
+              - docker volume ls -q | grep '^ddev-' | xargs -r docker volume rm -f || true
         - step:
             name: 🚀 Install Drupal & Run Automated Tests
             runs-on:
@@ -91,13 +97,15 @@ pipelines:
               - export DOCKER_HOST=""
               - export DOCKER_BUILDKIT=1
               - ddev -v
-              - ddev stop --unlist --all --omit-snapshot --remove-data
-              - yes | ddev delete --all --omit-snapshot
+              - ddev poweroff || true
+              - ddev stop --unlist --all --omit-snapshot --remove-data || true
+              - ddev delete --omit-snapshot --yes || true
+              - docker ps -aq --filter "name=ddev-" | xargs -r docker rm -f || true
+              - docker volume ls -q | grep '^ddev-' | xargs -r docker volume rm -f || true
               - ddev start
               - ddev add-on get Vardot/ddev-dev-tools
               - ddev restart
               - ddev install-drupal
-              - ddev dev-phpunit
               - FEATURE_FILES=$(find cypress -name "*.feature" -type f 2>/dev/null | wc -l)
               - echo "Found $FEATURE_FILES .feature files in cypress folder"
               - if [ "$FEATURE_FILES" -eq 0 ]; then
@@ -114,5 +122,8 @@ pipelines:
               - chmod 777 docroot/sites/default -R 2>/dev/null || chmod 777 web/sites/default -R 2>/dev/null || true
               - export DOCKER_HOST=""
               - export DOCKER_BUILDKIT=1
+              - ddev poweroff || true
               - ddev stop --unlist --all --omit-snapshot --remove-data || true
               - ddev delete --omit-snapshot --yes || true
+              - docker ps -aq --filter "name=ddev-" | xargs -r docker rm -f || true
+              - docker volume ls -q | grep '^ddev-' | xargs -r docker volume rm -f || true


### PR DESCRIPTION
This pull request updates the example Bitbucket Pipelines configuration to improve the cleanup and reset steps for DDEV and Docker resources, ensuring a more reliable and thorough environment reset during CI runs. The changes also update the version comment at the top of the file.

Pipeline cleanup improvements:

* Replaced and expanded DDEV cleanup commands to include `ddev poweroff`, more robust `ddev stop` and `ddev delete` commands with error tolerance, and added explicit removal of DDEV-related Docker containers and volumes to prevent resource leaks. [[1]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L58-R62) [[2]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2R80-R84) [[3]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L94-L100) [[4]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2R125-R129)

Other updates:

* Updated the version comment at the top of `bitbucket-pipelines.yml.example` from 2.2.1 to 2.2.2.