### PR TITLE
Pipelines 2.2.3 & Composer install step

### DIFF
--- a/examples/bitbucket-pipelines.yml.example
+++ b/examples/bitbucket-pipelines.yml.example
@@ -1,5 +1,5 @@
 #################
-# Version: 2.2.2
+# Version: 2.2.3
 #################
 triggers:
   pullrequest-push:
@@ -58,9 +58,8 @@ pipelines:
               - ddev poweroff || true
               - ddev stop --unlist --all --omit-snapshot --remove-data || true
               - ddev delete --omit-snapshot --yes || true
-              - docker ps -aq --filter "name=ddev-" | xargs -r docker rm -f || true
-              - docker volume ls -q | grep '^ddev-' | xargs -r docker volume rm -f || true
               - ddev start
+              - ddev auth ssh
               - ddev composer config --global github-oauth.github.com $GITHUB_TOKEN
               - ddev composer install --optimize-autoloader
               - echo "Cleaning up old .ddev command files & Drupal coder"
@@ -80,8 +79,13 @@ pipelines:
               - ddev poweroff || true
               - ddev stop --unlist --all --omit-snapshot --remove-data || true
               - ddev delete --omit-snapshot --yes || true
-              - docker ps -aq --filter "name=ddev-" | xargs -r docker rm -f || true
-              - docker volume ls -q | grep '^ddev-' | xargs -r docker volume rm -f || true
+            final:
+              name: 🧹 Cleanup
+              script:
+                - ddev poweroff || true
+                - ddev stop --unlist --all --omit-snapshot --remove-data || true
+                - ddev delete --omit-snapshot --yes || true
+                - chmod 777 $BITBUCKET_CLONE_DIR -R || true
         - step:
             name: 🚀 Install Drupal & Run Automated Tests
             runs-on:
@@ -100,12 +104,12 @@ pipelines:
               - ddev poweroff || true
               - ddev stop --unlist --all --omit-snapshot --remove-data || true
               - ddev delete --omit-snapshot --yes || true
-              - docker ps -aq --filter "name=ddev-" | xargs -r docker rm -f || true
-              - docker volume ls -q | grep '^ddev-' | xargs -r docker volume rm -f || true
               - ddev start
+              - ddev auth ssh
               - ddev add-on get Vardot/ddev-dev-tools
               - ddev restart
               - ddev install-drupal
+              - ddev dev-phpunit
               - FEATURE_FILES=$(find cypress -name "*.feature" -type f 2>/dev/null | wc -l)
               - echo "Found $FEATURE_FILES .feature files in cypress folder"
               - if [ "$FEATURE_FILES" -eq 0 ]; then
@@ -125,5 +129,10 @@ pipelines:
               - ddev poweroff || true
               - ddev stop --unlist --all --omit-snapshot --remove-data || true
               - ddev delete --omit-snapshot --yes || true
-              - docker ps -aq --filter "name=ddev-" | xargs -r docker rm -f || true
-              - docker volume ls -q | grep '^ddev-' | xargs -r docker volume rm -f || true
+            final:
+              name: 🧹 Cleanup
+              script:
+                - ddev poweroff || true
+                - ddev stop --unlist --all --omit-snapshot --remove-data || true
+                - ddev delete --omit-snapshot --yes || true
+                - chmod 777 $BITBUCKET_CLONE_DIR -R || true

--- a/install.yaml
+++ b/install.yaml
@@ -21,6 +21,7 @@ project_files:
   - commands/cypress/cypress-ui
 
 post_install_actions:
+  - ddev composer install
   - ddev exec composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
   - ddev exec composer require --dev drupal/coder:^8.3 dealerdirect/phpcodesniffer-composer-installer squizlabs/php_codesniffer:^3.7
   - ddev exec composer config allow-plugins.vincentlanglet/twig-cs-fixer true

--- a/install.yaml
+++ b/install.yaml
@@ -21,7 +21,7 @@ project_files:
   - commands/cypress/cypress-ui
 
 post_install_actions:
-  - ddev composer install
+  - ddev composer install --no-interaction
   - ddev exec composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
   - ddev exec composer require --dev drupal/coder:^8.3 dealerdirect/phpcodesniffer-composer-installer squizlabs/php_codesniffer:^3.7
   - ddev exec composer config allow-plugins.vincentlanglet/twig-cs-fixer true


### PR DESCRIPTION
This pull request updates the Bitbucket Pipelines example configuration and the install process to improve automation, cleanup, and reliability. The main changes focus on enhancing the pipeline steps for Drupal projects, including improved SSH authentication, automated testing, and more robust cleanup procedures.

**Bitbucket Pipelines improvements:**

* Added `ddev auth ssh` step to ensure SSH authentication is set up before running Composer and other commands that may require SSH access. [[1]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L61-R62) [[2]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L103-R112)
* Added `ddev dev-phpunit` step to automate running PHP unit tests as part of the Drupal installation pipeline.
* Introduced a dedicated `final` cleanup step in the pipeline, consolidating cleanup commands and adding a permission reset with `chmod 777 $BITBUCKET_CLONE_DIR -R` to handle file permission issues. [[1]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L83-R88) [[2]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L128-R138)
* Removed direct Docker container and volume cleanup commands, relying on DDEV commands and the new cleanup step for environment teardown. [[1]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L61-R62) [[2]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L83-R88) [[3]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L103-R112) [[4]](diffhunk://#diff-3249887c601a11b86b6a394417e4d15f037304a548c7ccf0cec3a3ece80943b2L128-R138)
* Updated the pipeline configuration version from 2.2.2 to 2.2.3.

**Install process enhancements:**

* Added `ddev composer install` to `post_install_actions` in `install.yaml` to ensure dependencies are installed immediately after setup.