### PR TITLE
Adjust drush set role for install-drupal script

### DIFF
--- a/commands/host/install-drupal
+++ b/commands/host/install-drupal
@@ -101,7 +101,7 @@ if ddev drush role:list | grep -q '^site_admin'; then
     ddev drush user:role:add "site_admin" "$admin_user"
 else
     # Find any role containing 'admin'
-    admin_roles=$(ddev drush role:list | grep 'admin' | awk '{print $1}')
+    admin_roles=$(ddev drush role:list --format=list | grep 'admin' | awk '{print $1}')
     if [ -n "$admin_roles" ]; then
         for role in $admin_roles; do
             ddev drush user:role:add "$role" "$admin_user"

--- a/commands/web/dev-lint
+++ b/commands/web/dev-lint
@@ -40,15 +40,15 @@ if [ "${IS_CI:-false}" = "TRUE" ]; then
         echo "✅ Skipping PHP static analysis"
     fi
 
-    if [ -n "${SECURITY_CHANGED_FILES:-}" ]; then
-        echo "➡ Drupal Security PHPCS..."
-        echo "$SECURITY_CHANGED_FILES" | tr ' ' '\n'
-        if ! .ddev/commands/web/dev-phpcs-security --files="$SECURITY_CHANGED_FILES"; then
-            LINT_STATUS=1
-        fi
-    else
-        echo "✅ Skipping Drupal Security PHPCS"
-    fi
+    #if [ -n "${SECURITY_CHANGED_FILES:-}" ]; then
+    #    echo "➡ Drupal Security PHPCS..."
+    #    echo "$SECURITY_CHANGED_FILES" | tr ' ' '\n'
+    #    if ! .ddev/commands/web/dev-phpcs-security --files="$SECURITY_CHANGED_FILES"; then
+    #        LINT_STATUS=1
+    #    fi
+    #else
+    #    echo "✅ Skipping Drupal Security PHPCS"
+    #fi
 
     if [ -n "${JS_CHANGED_FILES:-}" ]; then
         echo "➡ JS Linting..."
@@ -121,10 +121,10 @@ else
         LINT_STATUS=1
     fi
 
-    echo "➡ Drupal Security PHPCS..."
-    if ! .ddev/commands/web/dev-phpcs-security $ARGS; then
-        LINT_STATUS=1
-    fi
+    #echo "➡ Drupal Security PHPCS..."
+    #if ! .ddev/commands/web/dev-phpcs-security $ARGS; then
+    #    LINT_STATUS=1
+    #fi
 
     echo "➡ JS Linting..."
     if ! .ddev/commands/web/dev-eslint $ARGS; then

--- a/install.yaml
+++ b/install.yaml
@@ -10,7 +10,6 @@ project_files:
   - commands/web/dev-eslint
   - commands/web/dev-lint
   - commands/web/dev-phpcs
-  - commands/web/dev-phpcs-security
   - commands/web/dev-phpstan
   - commands/web/dev-phpunit
   - commands/web/dev-stylelint
@@ -24,7 +23,7 @@ project_files:
 post_install_actions:
   - ddev composer install --no-interaction
   - ddev exec composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-  - ddev exec composer require --dev drupal/coder:^8.3 dealerdirect/phpcodesniffer-composer-installer squizlabs/php_codesniffer:^3.7 mingsong-hu/drupalsecurity:^1.0
+  - ddev exec composer require --dev drupal/coder:^8.3 dealerdirect/phpcodesniffer-composer-installer squizlabs/php_codesniffer:^3.7
   - ddev exec composer config allow-plugins.vincentlanglet/twig-cs-fixer true
   - ddev exec composer require --dev vincentlanglet/twig-cs-fixer:^3.0
   - ddev exec composer config allow-plugins.phpstan/extension-installer true


### PR DESCRIPTION
This pull request primarily removes the Drupal Security PHPCS checks from the development linting workflow and related setup files. The main goal is to streamline the linting process by eliminating the use of the `mingsong-hu/drupalsecurity` package and its associated scripts.

**Linting and Security Checks:**

* Commented out all logic related to running Drupal Security PHPCS checks in the `commands/web/dev-lint` script, so these security checks are no longer executed during linting. [[1]](diffhunk://#diff-89a8a844f012fd8c2ea98d35f6ab0f743d6e2695b1e42cb2bbd54906100c17f1L43-R51) [[2]](diffhunk://#diff-89a8a844f012fd8c2ea98d35f6ab0f743d6e2695b1e42cb2bbd54906100c17f1L124-R127)
* Removed the `commands/web/dev-phpcs-security` script from the `install.yaml` project files, so it is no longer included in project setups.
* Removed the `mingsong-hu/drupalsecurity` package from the `composer require` command in `install.yaml`, so this dependency is no longer installed.

**Other Improvements:**

* Updated the `ddev drush role:list` command in `commands/host/install-drupal` to use the `--format=list` flag for more reliable role parsing.