### PR TITLE
feat: add dev-phpcbf command to auto-fix PHP files (issue #28)

### DIFF
--- a/commands/web/dev-phpcbf
+++ b/commands/web/dev-phpcbf
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+## #ddev-generated
+## Description: Run PHPCBF to auto-fix PHP files
+# Usage: ddev dev-phpcbf [--all] [--files=file1.php,file2.module]
+# Example: "ddev dev-phpcbf" (checks git diff)
+#          "ddev dev-phpcbf --all" (fixes all PHP files)
+#          "ddev dev-phpcbf --files=file1.php,file2.module" (fixes specific files)
+
+source "${0%/*}/dev-utils.sh"
+
+DEFAULT_EXTENSIONS=("php" "module")
+EXTENSIONS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ext=*)
+            IFS=',' read -r -a EXTENSIONS <<< "${1#--ext=}"
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ ${#EXTENSIONS[@]} -eq 0 ]; then
+    EXTENSIONS=("${DEFAULT_EXTENSIONS[@]}")
+fi
+
+FILES=""
+
+if [ $# -eq 0 ]; then
+    FILES=$(get_files "${EXTENSIONS[@]}")
+else
+    FILES=$(get_files "${EXTENSIONS[@]}" "$@")
+fi
+
+if [ -z "${FILES:-}" ]; then
+    echo "✅ No files to fix"
+    exit 0
+fi
+
+echo "Files to fix:"
+echo "$FILES" | tr ' ' '\n'
+
+# Check if phpcbf is executable
+check_command_executable "$(command -v phpcbf 2>/dev/null || echo '/var/www/html/bin/phpcbf')" "phpcbf"
+
+# Run PHPCBF with Drupal standards to auto-fix files
+phpcbf -- -s --colors --standard=Drupal,DrupalPractice --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md,yml --exclude=Drupal.Files.LineLength,Drupal.Files.TxtFileLineLength $FILES


### PR DESCRIPTION

## The Issue

- Fixes #28

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Adds a new ddev command similar to dev-phpcs for fixing linting issue with a command named dev-phpcbf

- Adds new PHPCBF linter that auto-fixes Drupal code style issues
- Supports --all, --files=, and default (git diff) modes
- Same extension filtering as dev-phpcs (--ext=php,module,inc,...)
- Excludes LineLength rules to avoid false negatives
- Documents usage in README.md


## Manual Testing Instructions

No, this PR just adds a new command for fixing issues.

```bash
ddev add-on get https://github.com/Vardot/ddev-dev-tools/tarball/refs/pull/28/head
ddev restart
```

## Automated Testing Overview

NA

## Release/Deployment Notes

NA
